### PR TITLE
Set PlatformTarget to AnyCPU

### DIFF
--- a/Standalone/Steamworks.NET.Standard.csproj
+++ b/Standalone/Steamworks.NET.Standard.csproj
@@ -5,7 +5,7 @@
 		<!--<TargetFramework>netstandard2.1</TargetFramework>-->
 		<RootNamespace>Steamworks</RootNamespace>
 		<AssemblyName>Steamworks.NET</AssemblyName>
-		<Platforms>x64;x86</Platforms>
+		<Platforms>AnyCPU</Platforms>
 		<Configurations>Windows;OSX-Linux</Configurations>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<RepositoryType>git</RepositoryType>
@@ -29,7 +29,7 @@
 		<DefineConstants>TRACE;STEAMWORKS_WIN;STEAMWORKS_X86</DefineConstants>
 		<Optimize>true</Optimize>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-		<PlatformTarget>x86</PlatformTarget>
+		<PlatformTarget>AnyCPU</PlatformTarget>
 		<ErrorReport>prompt</ErrorReport>
 	</PropertyGroup>
 
@@ -38,7 +38,7 @@
 		<DefineConstants>TRACE;STEAMWORKS_LIN_OSX;STEAMWORKS_X86</DefineConstants>
 		<Optimize>true</Optimize>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-		<PlatformTarget>x86</PlatformTarget>
+		<PlatformTarget>AnyCPU</PlatformTarget>
 		<ErrorReport>prompt</ErrorReport>
 	</PropertyGroup>
 
@@ -47,7 +47,7 @@
 		<DefineConstants>TRACE;STEAMWORKS_WIN;STEAMWORKS_X64</DefineConstants>
 		<Optimize>true</Optimize>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-		<PlatformTarget>x64</PlatformTarget>
+		<PlatformTarget>AnyCPU</PlatformTarget>
 		<ErrorReport>prompt</ErrorReport>
 	</PropertyGroup>
 
@@ -56,7 +56,7 @@
 		<DefineConstants>TRACE;STEAMWORKS_LIN_OSX;STEAMWORKS_X64</DefineConstants>
 		<Optimize>true</Optimize>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-		<PlatformTarget>x64</PlatformTarget>
+		<PlatformTarget>AnyCPU</PlatformTarget>
 		<ErrorReport>prompt</ErrorReport>
 	</PropertyGroup>
 


### PR DESCRIPTION
Update Steamworks.NET.Standard.csproj to allow ARM loading of the managed binary, allowing for reflection, and therefore fixing https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/2545.
I tested the win-x64 CI output with main graphical and headless clients, and didn't find any regressions. 

There might be a bigger issue with the repo itself. I had seemingly random CI build failures while working on this. It's something in Roslyn, but it's outside of my current knowledge with C#. 